### PR TITLE
Rename flags and explicit updating.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ To simplify deploying git based repositories.
 
 In order to accurately mirror an environment with git repositories, this project has to take on some responsibilities;
 
-- Git Cloning/Updating.
-- Environment.
-- Command Execution.
+- Git cloning/updating.
+- Environment handling.
+- Command execution.
 
 ## Dependencies
 
-This package does not have any dependenies on external packages or modules. It downloads all required files. However this means that an internet connection is required.
+This package does not have any dependencies on external packages or modules. It downloads all required files. However this means that an internet connection is required.
 
 Once a deployment has been run on various platforms (Windows, Linux and OSX), all dependencies should be downloaded and the entire folder can be shared without an internet connection required.
 
@@ -23,25 +23,35 @@ Once a deployment has been run on various platforms (Windows, Linux and OSX), al
 At the basic level you can use this project to just setup Conda and experiment with the root environment. Just execute the following command:
 
 ```
+startup.bat --environment root
 ```
 
-Create an environment file pointer in the repository, or modify ```environment.conf.example``` and rename to ```environment.conf```.
+### Arguments
 
-The environment file follows this syntax;
+To facilitate different uses the ```startup``` executables has a number of arguments.
 
-```yaml
-dependencies:
-   - git:
-     - "https://github.com/tokejepsen/conda-git-example.git":
-        - "python $REPO_PATH/startup.py"
-```
+Argument | Description | Example
+--- | --- | ---
+environment | Environment file to process. | ```startup.bat --environment https://raw.githubusercontent.com/tokejepsen/conda-git-example/master/environment.yml```
+attached | Spawn non-detached processes. | ```startup.bat --attached --environment https://raw.githubusercontent.com/tokejepsen/conda-git-example/master/environment.yml```
+update-environment | Update and rebuild environment. | ```startup.bat --update-environment --environment https://raw.githubusercontent.com/tokejepsen/conda-git-example/master/environment.yml```
+update-repositories | Update and rebuild repositories. | ```startup.bat --update-repositories --environment https://raw.githubusercontent.com/tokejepsen/conda-git-example/master/environment.yml```
+export | Exports the environment. | ```startup.bat --export --environment https://raw.githubusercontent.com/tokejepsen/conda-git-example/master/environment.yml```
+export-without-commit | Exports the environment, without commit ids. | ```startup.bat --export-without-commit --environment https://raw.githubusercontent.com/tokejepsen/conda-git-example/master/environment.yml```
 
-*Window* - You start the deployment by double-clicking the ```startup.bat``` on Windows, or running the ```startup.bat``` file in a terminal.
+## Location
 
-*Linux* - You start the deployment by executing this in a terminal; ```source path/to/repository/startup.sh```.
+Once the environment has been built in a location on disk, if you move the folder to a different location on disk, you will have to rebuild the environment.
 
-*OSX* - Coming soon.
+***NOTE: UNC paths are supported currently.***
 
-Using the example above will download the ```https://github.com/tokejepsen/conda-git-example.git``` repository, and execute the ```startup.py``` file inside. ```startup.py``` is dependent on PySide being installed, so it installs PySide with conda and displays a "Hello World" PySide window.
+## Utilities
 
-You can add git repositories (remote or local), which will be cloned and updated when ever the deployment is started.
+**update.bat**
+
+This batch script updates both the environment and the repositories. The same as the following
+
+```startup.bat --update-environment --update-repositories```
+
+- update-repositories.bat
+- update-environment.bat

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export-without-commit | Exports the environment, without commit ids. | ```startu
 
 Once the environment has been built in a location on disk, if you move the folder to a different location on disk, you will have to rebuild the environment.
 
-***NOTE: UNC paths are supported currently.***
+***NOTE: UNC paths are not supported currently.***
 
 ## Utilities
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,3 @@ Once the environment has been built in a location on disk, if you move the folde
 This batch script updates both the environment and the repositories. The same as the following
 
 ```startup.bat --update-environment --update-repositories```
-
-- update-repositories.bat
-- update-environment.bat

--- a/conda_git_deployment/environment.py
+++ b/conda_git_deployment/environment.py
@@ -45,6 +45,18 @@ def main():
 
         return
 
+    # If requested to put user into the root environment.
+    if environment == "root":
+
+        msg = "You are in the root environment of Conda. "
+        msg += "The \"conda\" command is available to use now."
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        path = path.replace("\\", "/")
+
+        print msg.format(path=path)
+
+        return
+
     # Get environment data.
     env_conf = None
     if os.path.exists(environment):

--- a/conda_git_deployment/install.py
+++ b/conda_git_deployment/install.py
@@ -62,7 +62,7 @@ def main():
                 repositories.append(data)
 
     # Update repositories.
-    if utils.get_arguments()["update"]:
+    if utils.get_arguments()["update-repositories"]:
         for repo in repositories:
             print repo["name"]
 
@@ -89,7 +89,7 @@ def main():
                 subprocess.call(["git", "checkout", tag], cwd=repo["path"])
 
     # Install any setup.py if we are updating
-    if utils.get_arguments()["update"]:
+    if utils.get_arguments()["update-repositories"]:
         for repo in repositories:
             if "setup.py" in os.listdir(repo["path"]):
                 args = ["python", "setup.py", "build"]

--- a/conda_git_deployment/update.py
+++ b/conda_git_deployment/update.py
@@ -19,7 +19,8 @@ def main():
 
 if __name__ == "__main__":
 
-    if utils.get_arguments()["update"]:
+    if (utils.get_arguments()["update-environment"] or
+       utils.get_arguments()["update-repositories"]):
         main()
 
     # Execute install

--- a/conda_git_deployment/utils.py
+++ b/conda_git_deployment/utils.py
@@ -87,20 +87,6 @@ def get_arguments():
     parser = argparse.ArgumentParser(description="conda-git-deployment")
 
     parser.add_argument(
-        "--update-environment",
-        action="store_true",
-        default=False,
-        dest="update-environment",
-        help="Update and rebuild environment."
-    )
-    parser.add_argument(
-        "--update-repositories",
-        action="store_true",
-        default=False,
-        dest="update-repositories",
-        help="Update and rebuild repositories."
-    )
-    parser.add_argument(
         "--environment",
         action="store",
         default="",
@@ -113,6 +99,20 @@ def get_arguments():
         default=False,
         dest="attached",
         help="Spawn non-detached processes."
+    )
+    parser.add_argument(
+        "--update-environment",
+        action="store_true",
+        default=False,
+        dest="update-environment",
+        help="Update and rebuild environment."
+    )
+    parser.add_argument(
+        "--update-repositories",
+        action="store_true",
+        default=False,
+        dest="update-repositories",
+        help="Update and rebuild repositories."
     )
     parser.add_argument(
         "--export",

--- a/conda_git_deployment/utils.py
+++ b/conda_git_deployment/utils.py
@@ -87,11 +87,18 @@ def get_arguments():
     parser = argparse.ArgumentParser(description="conda-git-deployment")
 
     parser.add_argument(
-        "--update",
+        "--update-environment",
         action="store_true",
         default=False,
-        dest="update",
-        help="Rebuild and updates an environment."
+        dest="update-environment",
+        help="Update and rebuild environment."
+    )
+    parser.add_argument(
+        "--update-repositories",
+        action="store_true",
+        default=False,
+        dest="update-repositories",
+        help="Update and rebuild repositories."
     )
     parser.add_argument(
         "--environment",
@@ -112,14 +119,14 @@ def get_arguments():
         action="store_true",
         default=False,
         dest="export",
-        help="Exports the current environment into the working directory."
+        help="Exports the environment."
     )
     parser.add_argument(
-        "--no-commit",
+        "--export-without-commit",
         action="store_true",
         default=False,
-        dest="no-commit",
-        help="Setting for export, to not include commit id."
+        dest="export-without-commit",
+        help="Exports the environment, without commit ids."
     )
 
     args, unknown = parser.parse_known_args()

--- a/utilities/reset.bat
+++ b/utilities/reset.bat
@@ -1,5 +1,0 @@
-REM Reset deployment by deleting repositories and conda directory, then reinstall.
-cd %~dp0
-cd ..
-@RD /S /Q windows
-startup.bat

--- a/utilities/update-environment.bat
+++ b/utilities/update-environment.bat
@@ -1,0 +1,3 @@
+cd %~dp0
+cd ..
+startup.bat --update-environment %*

--- a/utilities/update-repositories.bat
+++ b/utilities/update-repositories.bat
@@ -1,0 +1,3 @@
+cd %~dp0
+cd ..
+startup.bat --update-repositories %*

--- a/utilities/update.bat
+++ b/utilities/update.bat
@@ -1,3 +1,3 @@
 cd %~dp0
 cd ..
-startup.bat --update %*
+startup.bat --update-environment --update-repositories %*


### PR DESCRIPTION
Renamed "--no-commit" flag to "--export-without-commit", and made it independent of "--export".
Removed "--update" flag, and replaced with two explicit flags "--update-environment" and "--update-repositories".
Removed reset utility.