### PR TITLE
cmd.exe vs. UNC paths

### DIFF
--- a/startup.bat
+++ b/startup.bat
@@ -1,3 +1,7 @@
+:: Change the working directory to the conda-git-deployment directory.
+:: "pushd" is being used so any UNC paths get mapped until a restart happens.
+pushd %~dp0
+
 :: Isolating the execution environment.
 :: Powershell is needed for downloading miniconda.
 set PATH=C:\WINDOWS\System32\WindowsPowerShell\v1.0


### PR DESCRIPTION
**Motivation**

Feature to run from UNC paths.

CMD.exe and UNC paths are not friends, so we can't change the working directory when working with UNC paths. This affects lots of commands that rely on being in a certain working directory.

**Implementation**

By utilizing ```pushd``` we mount the UNC path to a drive letter and change the working directory to that drive letter.
The mount is not permanent across reboots.